### PR TITLE
Add Input handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,51 @@
 # Devcade-library
 A monogame library for allowing games to interact with cabinet functions.
 
+---
+
+- [Input](#input-wrapping)
+  - [ArcadeButtons enum](#arcadebuttons-enum)
+
+---
+---
+
 ## Input wrapping
 ### ArcadeButtons enum
-`Input.ArcadeButtons` is an enum with values A1 through A4, B1 through B4, Menu, StickUp, StickDown, StickRight, and StickLeft.
+`Input.ArcadeButtons` is an enum with values 
+- A1 through A4
+- B1 through B4
+- Menu
+- StickUp, StickDown, StickRight, and StickLeft
 
 These values are equivelant to values of the `Buttons` enum and can be used in place of them when explicitly cast to a `Buttons`. This allows existing controller input code to be easily adapted to the Devcade control scheme.
 
 Example:
 `gamePadState.IsButtonDown((Buttons)Devcade.Input.ArcadeButtons.Menu)`
+
+---
+### Get methods
+
+In order to use these methods `Input.Initialize()` must be called once before using them and `Input.Update()` must be called once each frame.
+
+#### `GetButton(int playerNum, ArcadeButtons button)`
+
+Given the player and button to check, it will return true if the button is down. This will return true on the initial press and for the duration that the button is held.
+
+#### `GetButtonDown(int playerNum, ArcadeButtons button)`
+
+Given the player and button to check, it will return true if the button is pressed down during the current frame. This only returns true on the initial press from up to down and will not trigger repeatedly while the button is held.
+
+#### `GetButtonUp(int playerNum, ArcadeButtons button)`
+
+Given the player and button to check, it will return true if the button is released during the current frame. This only returns true on the initial release from down to up and will not trigger repeatedly while the button is up.
+
+#### `GetButtonHeld(int playerNum, ArcadeButtons button)`
+
+Given the player and button to check, it will return true if the button is being held down. This will not return true for the initial press or the release.
+
+#### `GetStick(int playerNum)`
+
+Given the player it returns a `Vector2` representing the stick direction.
+
+---
+---

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ A monogame library for allowing games to interact with cabinet functions.
 
 - [Input](#input-wrapping)
   - [ArcadeButtons enum](#arcadebuttons-enum)
-
+  - [Get methods](#get-methods)
+  
 ---
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # Devcade-library
 A monogame library for allowing games to interact with cabinet functions.
+
+## Input wrapping
+### ArcadeButtons enum
+`Input.ArcadeButtons` is an enum with values A1 through A4, B1 through B4, Menu, StickUp, StickDown, StickRight, and StickLeft.
+
+These values are equivelant to values of the `Buttons` enum and can be used in place of them when explicitly cast to a `Buttons`. This allows existing controller input code to be easily adapted to the Devcade control scheme.
+
+Example:
+`gamePadState.IsButtonDown((Buttons)Devcade.Input.ArcadeButtons.Menu)`

--- a/devcade-library/Game1.cs
+++ b/devcade-library/Game1.cs
@@ -1,8 +1,0 @@
-﻿using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
-using Microsoft.Xna.Framework.Input;
-
-namespace devcade_library
-{
-    
-}

--- a/devcade-library/Input.cs
+++ b/devcade-library/Input.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.Xna.Framework.Input;
+
+namespace Devcade
+{
+  public static class Input
+  {
+    /// <summary>
+    /// Enum of button names available on the cabinet. Maps directly to the 
+    /// equivalent in the Buttons enum. Allows you to use existing controller 
+    /// logic and essentially just rename the buttons but you must explicitly 
+    /// cast it to a Button each time.
+    /// </summary>
+    public enum ArcadeButtons
+    {
+      A1=Buttons.X,
+      A2=Buttons.Y,
+      A3=Buttons.RightShoulder,
+      A4=Buttons.LeftShoulder,
+      B1=Buttons.A,
+      B2=Buttons.B,
+      B3=Buttons.RightTrigger,
+      B4=Buttons.LeftTrigger,
+      Menu=Buttons.Start,
+      StickDown=Buttons.LeftThumbstickDown,
+      StickUp=Buttons.LeftThumbstickUp,
+      StickLeft=Buttons.LeftThumbstickLeft,
+      StickRight=Buttons.LeftThumbstickRight
+    }
+  }
+}

--- a/devcade-library/Input.cs
+++ b/devcade-library/Input.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Xna.Framework.Input;
+using Microsoft.Xna.Framework;
 
 namespace Devcade
 {
@@ -26,5 +27,94 @@ namespace Devcade
       StickLeft=Buttons.LeftThumbstickLeft,
       StickRight=Buttons.LeftThumbstickRight
     }
+
+
+    private static GamePadState p1State;
+    private static GamePadState p1LastState;
+
+    private static GamePadState p2State;
+    private static GamePadState p2LastState;
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="playerNum"></param>
+    /// <param name="button"></param>
+    /// <returns></returns>
+    public static bool GetButton(int playerNum, ArcadeButtons button)
+    {
+
+      return false;
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="playerNum"></param>
+    /// <param name="button"></param>
+    /// <returns></returns>
+    public static bool GetButtonDown(int playerNum, ArcadeButtons button)
+    {
+
+      return false;
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="playerNum"></param>
+    /// <param name="button"></param>
+    /// <returns></returns>
+    public static bool GetButtonUp(int playerNum, ArcadeButtons button)
+    {
+
+      return false;
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="playerNum"></param>
+    /// <param name="button"></param>
+    /// <returns></returns>
+    public static bool GetButtonHeld(int playerNum, ArcadeButtons button)
+    {
+
+      return false;
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="playerNum"></param>
+    /// <returns></returns>
+    public static Vector2 GetStick(int playerNum)
+    {
+
+      return Vector2.Zero;
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public static void Initialize()
+    {
+      p1State = GamePad.GetState(0);
+      p2State = GamePad.GetState(1);
+      p1LastState = GamePad.GetState(0);
+      p2LastState = GamePad.GetState(1);
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public static void Update()
+    {
+      p1LastState = p1State;
+      p2LastState = p2State;
+      p1State = GamePad.GetState(0);
+      p2State = GamePad.GetState(1);
+    }
+
   }
 }

--- a/devcade-library/Input.cs
+++ b/devcade-library/Input.cs
@@ -28,12 +28,13 @@ namespace Devcade
       StickRight=Buttons.LeftThumbstickRight
     }
 
-
+    #region States
     private static GamePadState p1State;
     private static GamePadState p1LastState;
 
     private static GamePadState p2State;
     private static GamePadState p2LastState;
+    #endregion
 
     /// <summary>
     /// Checks if a button is currently pressed. 
@@ -55,7 +56,7 @@ namespace Devcade
     /// <param name="playerNum">The player whose controls should be checked.</param>
     /// <param name="button">The button to check.</param>
     /// <returns>True if the button was pressed last frame, false otherwise.</returns>
-    public static bool GetLastButton(int playerNum, ArcadeButtons button)
+    private static bool GetLastButton(int playerNum, ArcadeButtons button)
     {
       if (playerNum == 1 && p1LastState.IsButtonDown((Buttons)button)) { return true; }
       if (playerNum == 2 && p2LastState.IsButtonDown((Buttons)button)) { return true; }
@@ -68,49 +69,49 @@ namespace Devcade
     /// </summary>
     /// <param name="playerNum">The player whose controls should be checked.</param>
     /// <param name="button">The button to check.</param>
-    /// <returns>True if the button transitioned from up to down in the current frame.</returns>
+    /// <returns>True if the button transitioned from up to down in the current frame, false otherwise.</returns>
     public static bool GetButtonDown(int playerNum, ArcadeButtons button)
     {
       return (GetButton(playerNum, button) && !GetLastButton(playerNum, button));
     }
 
     /// <summary>
-    /// 
+    /// Checks if a button was released this frame.
     /// </summary>
-    /// <param name="playerNum"></param>
-    /// <param name="button"></param>
-    /// <returns></returns>
+    /// <param name="playerNum">The player whose controls should be checked.</param>
+    /// <param name="button">The button to check.</param>
+    /// <returns>True if the button transitioned from down to up in the current frame, false otherwise.</returns>
     public static bool GetButtonUp(int playerNum, ArcadeButtons button)
     {
-
-      return false;
+      return (!GetButton(playerNum, button) && GetLastButton(playerNum, button));
     }
 
     /// <summary>
-    /// 
+    /// Checks if a button is being held down.
     /// </summary>
-    /// <param name="playerNum"></param>
-    /// <param name="button"></param>
-    /// <returns></returns>
+    /// <param name="playerNum">The player whose controls should be checked.</param>
+    /// <param name="button">The button to check.</param>
+    /// <returns>True if the button was down last frame and is still down, false otherwise.</returns>
     public static bool GetButtonHeld(int playerNum, ArcadeButtons button)
     {
-
-      return false;
+      return (GetButton(playerNum, button) && GetLastButton(playerNum, button));
     }
 
     /// <summary>
-    /// 
+    /// Gets the stick position of a player.
     /// </summary>
-    /// <param name="playerNum"></param>
-    /// <returns></returns>
+    /// <param name="playerNum">The player whose controls should be checked.</param>
+    /// <returns>A Vector2 representing the stick direction.</returns>
     public static Vector2 GetStick(int playerNum)
     {
+      if (playerNum == 1) { return p1State.ThumbSticks.Left; }
+      if (playerNum == 2) { return p2State.ThumbSticks.Left; }
 
       return Vector2.Zero;
     }
 
     /// <summary>
-    /// 
+    /// Setup initial input states.
     /// </summary>
     public static void Initialize()
     {
@@ -121,7 +122,7 @@ namespace Devcade
     }
 
     /// <summary>
-    /// 
+    /// Updates input states.
     /// </summary>
     public static void Update()
     {
@@ -130,6 +131,5 @@ namespace Devcade
       p1State = GamePad.GetState(0);
       p2State = GamePad.GetState(1);
     }
-
   }
 }

--- a/devcade-library/Input.cs
+++ b/devcade-library/Input.cs
@@ -36,27 +36,42 @@ namespace Devcade
     private static GamePadState p2LastState;
 
     /// <summary>
-    /// 
+    /// Checks if a button is currently pressed. 
     /// </summary>
-    /// <param name="playerNum"></param>
-    /// <param name="button"></param>
-    /// <returns></returns>
+    /// <param name="playerNum">The player whose controls should be checked.</param>
+    /// <param name="button">The button to check.</param>
+    /// <returns>True when button is pressed, false otherwise.</returns>
     public static bool GetButton(int playerNum, ArcadeButtons button)
     {
+      if (playerNum == 1 && p1State.IsButtonDown((Buttons)button)) { return true; }
+      if (playerNum == 2 && p2State.IsButtonDown((Buttons)button)) { return true; }
 
       return false;
     }
 
     /// <summary>
-    /// 
+    /// Checks if a button was pressed last frame. 
     /// </summary>
-    /// <param name="playerNum"></param>
-    /// <param name="button"></param>
-    /// <returns></returns>
-    public static bool GetButtonDown(int playerNum, ArcadeButtons button)
+    /// <param name="playerNum">The player whose controls should be checked.</param>
+    /// <param name="button">The button to check.</param>
+    /// <returns>True if the button was pressed last frame, false otherwise.</returns>
+    public static bool GetLastButton(int playerNum, ArcadeButtons button)
     {
+      if (playerNum == 1 && p1LastState.IsButtonDown((Buttons)button)) { return true; }
+      if (playerNum == 2 && p2LastState.IsButtonDown((Buttons)button)) { return true; }
 
       return false;
+    }
+
+    /// <summary>
+    /// Checks if a button was pressed down this frame.
+    /// </summary>
+    /// <param name="playerNum">The player whose controls should be checked.</param>
+    /// <param name="button">The button to check.</param>
+    /// <returns>True if the button transitioned from up to down in the current frame.</returns>
+    public static bool GetButtonDown(int playerNum, ArcadeButtons button)
+    {
+      return (GetButton(playerNum, button) && !GetLastButton(playerNum, button));
     }
 
     /// <summary>

--- a/devcade-library/devcade-library.csproj
+++ b/devcade-library/devcade-library.csproj
@@ -1,10 +1,25 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <RootNamespace>Devcade</RootNamespace>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <Company>Computer Science House</Company>
+    <Product>Devcade</Product>
+    <Authors>Noah Emke</Authors>
+    <Description>A monogame library for allowing games to interact with Devcade cabinet functions.</Description>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <RepositoryUrl>https://github.com/ComputerScienceHouse/Devcade-library</RepositoryUrl>
+    <RepositoryType>Github</RepositoryType>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.0.1641">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\LICENSE">
+      <Pack>True</Pack>
+      <PackagePath></PackagePath>
+    </None>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This will add wrapping and handling of input to the library.

- [x] Enum of equivalent `Buttons`
- [ ] ~~(nice but not needed) Remove the need to explicitly cast the enum when using monogame input methods~~
- [x] State tracking with `GetButton`, `GetButtonDown`, `GetButtonUp`, and `GetButtonHeld` methods
- [ ] ~~(just not necessary right now) Convenience properties for each button so users can just `Input.A1` and get whether it is pressed or not through an object for each player~~
- [ ] ~~(maybe later) Perhaps look at integrating Joe's event-based input manager~~