### PR TITLE
Fixed documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Devcade-library
 A monogame library for allowing games to interact with cabinet functions.
 
+
+To install or update this package, either use the dotnet cli by running `dotnet add package devcade-library`, or in Visual Studio go to Project > Manage NuGet Packages menu and search for devcade-library.
+
 ---
 
 - [Input](#input-wrapping)
@@ -96,15 +99,15 @@ if (Devcade.Input.GetStick(1).Y < 0){
 
 ## Save data
 
-Before any data is saved `Init()` must be called once. This sets up the thread that will handle saving and loading.
+Before any data is saved `Persistence.Init()` must be called once. This sets up the thread that will handle saving and loading.
 
-The two main methods are `SaveData.Save()` and `SaveData.Load<T>()`. These are used to save and load data respectively, and are both asynchronous. Thus, they return a `Task<Result>`. This can be awaited or ignored as needed.
+The two main methods are `Persistence.Save()` and `Persistence.Load<T>()`. These are used to save and load data respectively, and are both asynchronous. Thus, they return a `Task<Result>`. This can be awaited or ignored as needed.
 
-Sync versions of these methods are also available. These are `SaveData.SaveSync()` and `SaveData.LoadSync<T>()`. These are not recommended for many saves/loads at once as they will block the main thread while saving and loading.
+Sync versions of these methods are also available. These are `Persistence.SaveSync()` and `Persistence.LoadSync<T>()`. These are not recommended for many saves/loads at once as they will block the main thread while saving and loading.
 
 ### Saving data
 
-`SaveData.Save(string group, string key, T value, JsonSerializationSettings serializerOptions = null)`
+`Persistence.Save(string group, string key, T value, JsonSerializationSettings serializerOptions = null)`
 
 All data in a given group are stored in the same file, so using multiple groups can prevent key collisions and speed up loading for large amounts of data.
 
@@ -116,7 +119,7 @@ The serializerOptions parameter is optional and allows for customizing the seria
 
 ### Loading data
 
-`SaveData.Load<T>(string group, string key, JsonSerializationSettings serializerOptions = null)`
+`Persistence.Load<T>(string group, string key, JsonSerializationSettings serializerOptions = null)`
 
 This method returns the data saved with the given key in the given group. If no data is found it will return the default value for the type.
 
@@ -128,4 +131,4 @@ The serializerOptions parameter is optional and allows for customizing the seria
 
 ### Additional Save/Load info
 
-The data is saved by the onboard backend to the file system currently. While running locally this will save data to the current directory, although this can be changed through the `SetLocalPath()` method.
+The data is saved by the onboard backend to the file system currently. While running locally this will save data to the current directory, although this can be changed through the `Persistence.SetLocalPath()` method.

--- a/devcade-library/devcade-library.csproj
+++ b/devcade-library/devcade-library.csproj
@@ -16,7 +16,7 @@
     <PackageProjectUrl>https://devcade.csh.rit.edu/</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>Added save and load functions to communicate with a new backend.</PackageReleaseNotes>
-    <GenerateDocumentationFile>False</GenerateDocumentationFile>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.0.1641">


### PR DESCRIPTION
Fixed readme to reflect the name change from SaveData to Persistence.
Checked the box to include documentation in the nuget package.
Added installation instructions to readme.

- [x] Bumped version num to 2.0.1
- [x] Updated package changelog
- [x] New package ready for upload